### PR TITLE
Feat/Chapter6: 내 리뷰 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,34 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // QueryDSL : OpenFeign
+    implementation "io.github.openfeign.querydsl:querydsl-jpa:7.0"
+    implementation "io.github.openfeign.querydsl:querydsl-core:7.0"
+    annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:7.0:jpa"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// QueryDSL 관련 설정
+// generated/querydsl 폴더 생성 & 삽입
+def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
+
+// 소스 세트에 생성 경로 추가 (구체적인 경로 지정)
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+// 컴파일 시 생성 경로 지정
+tasks.withType(JavaCompile).configureEach {
+    options.generatedSourceOutputDirectory.set(querydslDir)
+}
+
+// clean 태스크에 생성 폴더 삭제 로직 추가
+clean.doLast {
+    file(querydslDir).deleteDir()
 }

--- a/src/main/java/com/example/umc_mission/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/umc_mission/domain/review/controller/ReviewController.java
@@ -1,0 +1,38 @@
+package com.example.umc_mission.domain.review.controller;
+
+import com.example.umc_mission.domain.review.dto.ReviewDto;
+import com.example.umc_mission.domain.review.service.ReviewQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class ReviewController {
+
+    private final ReviewQueryService reviewQueryService;
+
+    @GetMapping("/reviews/search")
+    public List<ReviewDto> searchReview(
+            @RequestParam String query,
+            @RequestParam String type
+    ){
+
+        // 서비스에게 요청
+        return reviewQueryService.searchReview(query, type);
+
+    }
+
+    @GetMapping("/reviews")
+    public List<ReviewDto> getMyReviews(
+            @RequestParam Long memberId, // 임시 쿼리
+            @RequestParam(required = false) String query,
+            @RequestParam(required = false) String type
+    ){
+        return reviewQueryService.getMyReviews(memberId, query, type);
+    }
+
+}

--- a/src/main/java/com/example/umc_mission/domain/review/dto/ReviewDto.java
+++ b/src/main/java/com/example/umc_mission/domain/review/dto/ReviewDto.java
@@ -1,0 +1,18 @@
+package com.example.umc_mission.domain.review.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewDto {
+
+    private Long id;
+    private String content;
+    private Float star;
+    private Long storeId;
+    private Long memberId;
+
+}

--- a/src/main/java/com/example/umc_mission/domain/review/repository/ReviewQueryDsl.java
+++ b/src/main/java/com/example/umc_mission/domain/review/repository/ReviewQueryDsl.java
@@ -1,0 +1,20 @@
+package com.example.umc_mission.domain.review.repository;
+
+import com.example.umc_mission.domain.review.dto.ReviewDto;
+import com.example.umc_mission.domain.review.entity.Review;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
+
+import java.util.List;
+
+public interface ReviewQueryDsl {
+
+    // 검색 API
+    List<ReviewDto> searchReview(
+            Predicate predicate
+    );
+
+    List<ReviewDto> getMyReviews(
+            Predicate predicate
+    );
+}

--- a/src/main/java/com/example/umc_mission/domain/review/repository/ReviewQueryDslImpl.java
+++ b/src/main/java/com/example/umc_mission/domain/review/repository/ReviewQueryDslImpl.java
@@ -1,0 +1,77 @@
+package com.example.umc_mission.domain.review.repository;
+
+import com.example.umc_mission.domain.review.dto.ReviewDto;
+import com.example.umc_mission.domain.review.entity.QReview;
+import com.example.umc_mission.domain.store.entity.QLocation;
+import com.example.umc_mission.domain.store.entity.QStore;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewQueryDslImpl implements ReviewQueryDsl {
+
+    private final EntityManager em;
+
+    // Q클래스 선언
+    QReview review = QReview.review;
+    QStore store = QStore.store;
+    QLocation location = QLocation.location;
+
+    // 검색 API
+    @Override
+    public List<ReviewDto> searchReview(
+            Predicate predicate
+    ){
+
+        // JPA 세팅
+        JPAQueryFactory queryFactory = new JPAQueryFactory(em);
+
+        return queryFactory
+                .select(Projections.constructor(
+                        ReviewDto.class,
+                        review.id,
+                        review.content,
+                        review.star,
+                        review.store.id,
+                        review.member.id
+                        ))
+                .from(review)
+                .leftJoin(store).on(store.id.eq(review.store.id))
+                .leftJoin(location).on(location.id.eq(store.location.id))
+                .where(predicate)
+                .fetch();
+    }
+
+    // 조회 API
+    @Override
+    public List<ReviewDto> getMyReviews(
+            Predicate predicate
+    ){
+
+        // JPA 세팅
+        JPAQueryFactory queryFactory = new JPAQueryFactory(em);
+
+        return queryFactory
+                .select(Projections.constructor(
+                        ReviewDto.class,
+                        review.id,
+                        review.content,
+                        review.star,
+                        review.store.id,
+                        review.member.id
+                ))
+                .from(review)
+                .leftJoin(review.store, store)
+                .where(predicate)
+                .fetch();
+
+    }
+
+}

--- a/src/main/java/com/example/umc_mission/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/umc_mission/domain/review/repository/ReviewRepository.java
@@ -1,11 +1,14 @@
 package com.example.umc_mission.domain.review.repository;
 
+import com.example.umc_mission.domain.review.entity.QReview;
 import com.example.umc_mission.domain.review.entity.Review;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ReviewRepository extends JpaRepository<Review, Long> {
+import java.util.List;
 
-    //리뷰 작성
-    //Review save(Review review);
+public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewQueryDsl {
 
 }

--- a/src/main/java/com/example/umc_mission/domain/review/service/ReviewQueryService.java
+++ b/src/main/java/com/example/umc_mission/domain/review/service/ReviewQueryService.java
@@ -1,0 +1,114 @@
+package com.example.umc_mission.domain.review.service;
+
+import com.example.umc_mission.domain.review.dto.ReviewDto;
+import com.example.umc_mission.domain.review.entity.QReview;
+import com.example.umc_mission.domain.review.repository.ReviewRepository;
+import com.example.umc_mission.domain.store.entity.QLocation;
+import com.example.umc_mission.domain.store.entity.QStore;
+import com.querydsl.core.BooleanBuilder;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewQueryService {
+
+    private final ReviewRepository reviewRepository;
+    private final EntityManager em;
+
+    // Q클래스 정의
+    QReview review = QReview.review;
+    QLocation location = QLocation.location;
+    QStore store = QStore.store;
+
+    // 쿼리 테스트
+    public List<ReviewDto> searchReview(
+            String query,
+            String type
+    ){
+
+        // BooleanBuilder 정의
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // BooleanBuilder 사용
+
+        // 동적 쿼리: 검색 조건
+        if (type.equals("location")) {
+            builder.and(location.name.contains(query));
+        }
+        if (type.equals("star")) {
+            builder.and(review.star.goe(Float.parseFloat(query)));
+        }
+        if (type.equals("both")) {
+
+            // & 기준 변환
+            String firstQuery = query.split("&")[0];
+            String secondQuery = query.split("&")[1];
+
+            // 동적 쿼리
+            builder.and(location.name.contains(firstQuery));
+            builder.and(review.star.goe(Float.parseFloat(secondQuery)));
+
+        }
+
+        // Repository 사용 & 결과 매핑
+        List<ReviewDto> reviewList = reviewRepository.searchReview(builder);
+
+        // 리턴
+        return reviewList;
+    }
+
+    public List<ReviewDto> getMyReviews(
+            Long memberId, // 임시 쿼리
+            String query,
+            String type
+    ) {
+
+        // BooleanBuilder 정의
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // BooleanBuilder 사용
+
+        // 동적 쿼리: 필터 적용
+
+        builder.and(review.member.id.eq(memberId));
+
+        // 필터 미지정 시 내 리뷰 조회
+        if (type == null || type.isBlank()) {
+            return reviewRepository.getMyReviews(builder);
+        }
+
+        if (type.equals("store")) {
+            builder.and(store.name.contains(query));
+        }
+
+        if (type.equals("star")) {
+            float star = Float.parseFloat(query);
+            builder.and(review.star.goe(star))
+                    .and(review.star.lt(star + 1.0f));
+        }
+
+        if (type.equals("both")) {
+
+            String[] parts = query.split("&",2);
+
+            String storeQ = parts[0].trim();
+            float star = Float.parseFloat(parts[1].trim());
+
+            builder.and(store.name.contains(storeQ));
+            builder.and(review.star.goe(star))
+                    .and(review.star.lt(star + 1.0f));
+
+        }
+
+        // Repository 사용 & 결과 매핑
+        List<ReviewDto> reviewList = reviewRepository.searchReview(builder);
+
+        // 리턴
+        return reviewList;
+
+    }
+}

--- a/src/main/java/com/example/umc_mission/global/config/QueryDslConfig.java
+++ b/src/main/java/com/example/umc_mission/global/config/QueryDslConfig.java
@@ -1,0 +1,16 @@
+package com.example.umc_mission.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+
+}


### PR DESCRIPTION
## 💬 작성자 닉네임
- 오리/조예슬

## 🛠️ 작업 내용
- 6주차: 내가 작성한 리뷰 조회 API를 QueryDSL로 구현
- 가게별 & 별점대별 필터링
- 더미 데이터 추가
- 인증 관련 절차가 아직 없어 memberId를 임의 쿼리로 처리 >> 추후 수정 예정

## 📸 Suggestion 스크린샷
- 4점대 리뷰 조회 예시
- 가게별 리뷰 조회 예시
<img width="927" height="137" alt="image" src="https://github.com/user-attachments/assets/b26a5f52-1e23-4591-a98b-c0de86f90a47" />
<img width="862" height="178" alt="image" src="https://github.com/user-attachments/assets/cc77f560-cbe6-4c6f-a8e7-1f68b6260162" />

## 🔗 관련 이슈
- 해당 없음
